### PR TITLE
Link to math lib with -lm - closes #1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CC=cc
 CFLAGS=-c -O -g -I/usr/local/include -I/usr/X11R6/include
 LDFLAGS=-L/usr/local/lib -L/usr/X11R6/lib
-LDLIBS=-lglfw -lGLESv2 -lopenal -lvorbisfile
+LDLIBS=-lglfw -lGLESv2 -lopenal -lvorbisfile -lm
 
 OBJ=src/main.o   \
     src/data.o   \


### PR DESCRIPTION
This fixes the compile step for me on Debian. I'm not sure if it breaks things for OpenBSD.